### PR TITLE
First ydb-go-sdk generation version (See #4)

### DIFF
--- a/examples/authors/sqlc.yaml
+++ b/examples/authors/sqlc.yaml
@@ -52,6 +52,7 @@ sql:
       package: authors
       out: ydb
       emit_json_tags: true
+      sql_package: ydb-go-sdk
 
 
 rules:

--- a/examples/authors/ydb/db.go
+++ b/examples/authors/ydb/db.go
@@ -6,26 +6,20 @@ package authors
 
 import (
 	"context"
-	"database/sql"
+
+	"github.com/ydb-platform/ydb-go-sdk/v3/query"
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
-	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	Exec(ctx context.Context, sql string, opts ...query.ExecuteOption) error
+	Query(ctx context.Context, sql string, opts ...query.ExecuteOption) (query.Result, error)
+	QueryResultSet(ctx context.Context, sql string, opts ...query.ExecuteOption) (query.ClosableResultSet, error)
+	QueryRow(ctx context.Context, sql string, opts ...query.ExecuteOption) (query.Row, error)
 }
 
-func New(db DBTX) *Queries {
-	return &Queries{db: db}
+func New() *Queries {
+	return &Queries{}
 }
 
 type Queries struct {
-	db DBTX
-}
-
-func (q *Queries) WithTx(tx *sql.Tx) *Queries {
-	return &Queries{
-		db: tx,
-	}
 }

--- a/examples/authors/ydb/query.sql
+++ b/examples/authors/ydb/query.sql
@@ -16,14 +16,8 @@ WHERE bio IS NULL;
 -- name: Count :one
 SELECT COUNT(*) FROM authors;
 
--- name: COALESCE :many
-SELECT id, name, COALESCE(bio, 'Null value!') FROM authors;
-
--- name: CreateOrUpdateAuthor :execresult 
-UPSERT INTO authors (id, name, bio) VALUES ($p0, $p1, $p2);
-
--- name: CreateOrUpdateAuthorReturningBio :one
-UPSERT INTO authors (id, name, bio) VALUES ($p0, $p1, $p2) RETURNING bio;
+-- name: UpsertAuthor :queryrows
+UPSERT INTO authors (id, name, bio) VALUES ($p0, $p1, $p2) RETURNING *;
 
 -- name: DeleteAuthor :exec 
 DELETE FROM authors WHERE id = $p0;

--- a/examples/authors/ydb/query.sql.go
+++ b/examples/authors/ydb/query.sql.go
@@ -7,91 +7,43 @@ package authors
 
 import (
 	"context"
-	"database/sql"
+
+	"github.com/ydb-platform/ydb-go-sdk/v3"
+	"github.com/ydb-platform/ydb-go-sdk/v3/pkg/xerrors"
+	"github.com/ydb-platform/ydb-go-sdk/v3/query"
 )
-
-const cOALESCE = `-- name: COALESCE :many
-SELECT id, name, COALESCE(bio, 'Null value!') FROM authors
-`
-
-type COALESCERow struct {
-	ID   uint64 `json:"id"`
-	Name string `json:"name"`
-	Bio  string `json:"bio"`
-}
-
-func (q *Queries) COALESCE(ctx context.Context) ([]COALESCERow, error) {
-	rows, err := q.db.QueryContext(ctx, cOALESCE)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	var items []COALESCERow
-	for rows.Next() {
-		var i COALESCERow
-		if err := rows.Scan(&i.ID, &i.Name, &i.Bio); err != nil {
-			return nil, err
-		}
-		items = append(items, i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
 
 const count = `-- name: Count :one
 SELECT COUNT(*) FROM authors
 `
 
-func (q *Queries) Count(ctx context.Context) (uint64, error) {
-	row := q.db.QueryRowContext(ctx, count)
+func (q *Queries) Count(ctx context.Context, db DBTX, opts ...query.ExecuteOption) (uint64, error) {
+	row, err := db.QueryRow(ctx, count, opts...)
 	var count uint64
-	err := row.Scan(&count)
-	return count, err
-}
-
-const createOrUpdateAuthor = `-- name: CreateOrUpdateAuthor :execresult
-UPSERT INTO authors (id, name, bio) VALUES ($p0, $p1, $p2)
-`
-
-type CreateOrUpdateAuthorParams struct {
-	P0 uint64  `json:"p0"`
-	P1 string  `json:"p1"`
-	P2 *string `json:"p2"`
-}
-
-func (q *Queries) CreateOrUpdateAuthor(ctx context.Context, arg CreateOrUpdateAuthorParams) (sql.Result, error) {
-	return q.db.ExecContext(ctx, createOrUpdateAuthor, arg.P0, arg.P1, arg.P2)
-}
-
-const createOrUpdateAuthorReturningBio = `-- name: CreateOrUpdateAuthorReturningBio :one
-UPSERT INTO authors (id, name, bio) VALUES ($p0, $p1, $p2) RETURNING bio
-`
-
-type CreateOrUpdateAuthorReturningBioParams struct {
-	P0 uint64  `json:"p0"`
-	P1 string  `json:"p1"`
-	P2 *string `json:"p2"`
-}
-
-func (q *Queries) CreateOrUpdateAuthorReturningBio(ctx context.Context, arg CreateOrUpdateAuthorReturningBioParams) (*string, error) {
-	row := q.db.QueryRowContext(ctx, createOrUpdateAuthorReturningBio, arg.P0, arg.P1, arg.P2)
-	var bio *string
-	err := row.Scan(&bio)
-	return bio, err
+	if err != nil {
+		return count, xerrors.WithStackTrace(err)
+	}
+	err = row.Scan(&count)
+	if err != nil {
+		return count, xerrors.WithStackTrace(err)
+	}
+	return count, nil
 }
 
 const deleteAuthor = `-- name: DeleteAuthor :exec
 DELETE FROM authors WHERE id = $p0
 `
 
-func (q *Queries) DeleteAuthor(ctx context.Context, p0 uint64) error {
-	_, err := q.db.ExecContext(ctx, deleteAuthor, p0)
-	return err
+func (q *Queries) DeleteAuthor(ctx context.Context, db DBTX, p0 uint64, opts ...query.ExecuteOption) error {
+	err := db.Exec(ctx, deleteAuthor,
+		append(opts, query.WithParameters(ydb.ParamsFromMap(map[string]any{
+			"$p0": p0,
+		})))...,
+	)
+	if err != nil {
+		return xerrors.WithStackTrace(err)
+	}
+	return nil
 }
 
 const getAuthor = `-- name: GetAuthor :one
@@ -99,11 +51,21 @@ SELECT id, name, bio FROM authors
 WHERE id = $p0
 `
 
-func (q *Queries) GetAuthor(ctx context.Context, p0 uint64) (Author, error) {
-	row := q.db.QueryRowContext(ctx, getAuthor, p0)
+func (q *Queries) GetAuthor(ctx context.Context, db DBTX, p0 uint64, opts ...query.ExecuteOption) (Author, error) {
+	row, err := db.QueryRow(ctx, getAuthor,
+		append(opts, query.WithParameters(ydb.ParamsFromMap(map[string]any{
+			"$p0": p0,
+		})))...,
+	)
 	var i Author
-	err := row.Scan(&i.ID, &i.Name, &i.Bio)
-	return i, err
+	if err != nil {
+		return i, xerrors.WithStackTrace(err)
+	}
+	err = row.Scan(&i.ID, &i.Name, &i.Bio)
+	if err != nil {
+		return i, xerrors.WithStackTrace(err)
+	}
+	return i, nil
 }
 
 const getAuthorsByName = `-- name: GetAuthorsByName :many
@@ -111,25 +73,25 @@ SELECT id, name, bio FROM authors
 WHERE name = $p0
 `
 
-func (q *Queries) GetAuthorsByName(ctx context.Context, p0 string) ([]Author, error) {
-	rows, err := q.db.QueryContext(ctx, getAuthorsByName, p0)
+func (q *Queries) GetAuthorsByName(ctx context.Context, db DBTX, p0 string, opts ...query.ExecuteOption) ([]Author, error) {
+	res, err := db.QueryResultSet(ctx, getAuthorsByName,
+		append(opts, query.WithParameters(ydb.ParamsFromMap(map[string]any{
+			"$p0": p0,
+		})))...,
+	)
 	if err != nil {
-		return nil, err
+		return nil, xerrors.WithStackTrace(err)
 	}
-	defer rows.Close()
 	var items []Author
-	for rows.Next() {
+	for row := range res.Rows(ctx) {
 		var i Author
-		if err := rows.Scan(&i.ID, &i.Name, &i.Bio); err != nil {
-			return nil, err
+		if err := row.Scan(&i.ID, &i.Name, &i.Bio); err != nil {
+			return nil, xerrors.WithStackTrace(err)
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
+	if err := res.Close(ctx); err != nil {
+		return nil, xerrors.WithStackTrace(err)
 	}
 	return items, nil
 }
@@ -138,25 +100,21 @@ const listAuthors = `-- name: ListAuthors :many
 SELECT id, name, bio FROM authors
 `
 
-func (q *Queries) ListAuthors(ctx context.Context) ([]Author, error) {
-	rows, err := q.db.QueryContext(ctx, listAuthors)
+func (q *Queries) ListAuthors(ctx context.Context, db DBTX, opts ...query.ExecuteOption) ([]Author, error) {
+	res, err := db.QueryResultSet(ctx, listAuthors, opts...)
 	if err != nil {
-		return nil, err
+		return nil, xerrors.WithStackTrace(err)
 	}
-	defer rows.Close()
 	var items []Author
-	for rows.Next() {
+	for row := range res.Rows(ctx) {
 		var i Author
-		if err := rows.Scan(&i.ID, &i.Name, &i.Bio); err != nil {
-			return nil, err
+		if err := row.Scan(&i.ID, &i.Name, &i.Bio); err != nil {
+			return nil, xerrors.WithStackTrace(err)
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
+	if err := res.Close(ctx); err != nil {
+		return nil, xerrors.WithStackTrace(err)
 	}
 	return items, nil
 }
@@ -166,25 +124,21 @@ SELECT id, name, bio FROM authors
 WHERE bio IS NULL
 `
 
-func (q *Queries) ListAuthorsWithNullBio(ctx context.Context) ([]Author, error) {
-	rows, err := q.db.QueryContext(ctx, listAuthorsWithNullBio)
+func (q *Queries) ListAuthorsWithNullBio(ctx context.Context, db DBTX, opts ...query.ExecuteOption) ([]Author, error) {
+	res, err := db.QueryResultSet(ctx, listAuthorsWithNullBio, opts...)
 	if err != nil {
-		return nil, err
+		return nil, xerrors.WithStackTrace(err)
 	}
-	defer rows.Close()
 	var items []Author
-	for rows.Next() {
+	for row := range res.Rows(ctx) {
 		var i Author
-		if err := rows.Scan(&i.ID, &i.Name, &i.Bio); err != nil {
-			return nil, err
+		if err := row.Scan(&i.ID, &i.Name, &i.Bio); err != nil {
+			return nil, xerrors.WithStackTrace(err)
 		}
 		items = append(items, i)
 	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
+	if err := res.Close(ctx); err != nil {
+		return nil, xerrors.WithStackTrace(err)
 	}
 	return items, nil
 }
@@ -199,9 +153,64 @@ type UpdateAuthorByIDParams struct {
 	P2 uint64  `json:"p2"`
 }
 
-func (q *Queries) UpdateAuthorByID(ctx context.Context, arg UpdateAuthorByIDParams) (Author, error) {
-	row := q.db.QueryRowContext(ctx, updateAuthorByID, arg.P0, arg.P1, arg.P2)
+func (q *Queries) UpdateAuthorByID(ctx context.Context, db DBTX, arg UpdateAuthorByIDParams, opts ...query.ExecuteOption) (Author, error) {
+	row, err := db.QueryRow(ctx, updateAuthorByID,
+		append(opts, query.WithParameters(ydb.ParamsFromMap(map[string]any{
+			"$p0": arg.P0,
+			"$p1": arg.P1,
+			"$p2": arg.P2,
+		})))...,
+	)
 	var i Author
-	err := row.Scan(&i.ID, &i.Name, &i.Bio)
-	return i, err
+	if err != nil {
+		return i, xerrors.WithStackTrace(err)
+	}
+	err = row.Scan(&i.ID, &i.Name, &i.Bio)
+	if err != nil {
+		return i, xerrors.WithStackTrace(err)
+	}
+	return i, nil
+}
+
+const upsertAuthor = `-- name: UpsertAuthor :queryrows
+UPSERT INTO authors (id, name, bio) VALUES ($p0, $p1, $p2) RETURNING id, name, bio
+`
+
+type UpsertAuthorParams struct {
+	P0 uint64  `json:"p0"`
+	P1 string  `json:"p1"`
+	P2 *string `json:"p2"`
+}
+
+func (q *Queries) UpsertAuthor(ctx context.Context, db DBTX, arg UpsertAuthorParams, opts ...query.ExecuteOption) ([]Author, error) {
+	result, err := db.Query(ctx, upsertAuthor,
+		append(opts, query.WithParameters(ydb.ParamsFromMap(map[string]any{
+			"$p0": arg.P0,
+			"$p1": arg.P1,
+			"$p2": arg.P2,
+		})))...,
+	)
+	if err != nil {
+		return nil, xerrors.WithStackTrace(err)
+	}
+	var items []Author
+	for set, err := range result.ResultSets(ctx) {
+		if err != nil {
+			return nil, xerrors.WithStackTrace(err)
+		}
+		for row, err := range set.Rows(ctx) {
+			if err != nil {
+				return nil, xerrors.WithStackTrace(err)
+			}
+			var i Author
+			if err := row.Scan(&i.ID, &i.Name, &i.Bio); err != nil {
+				return nil, xerrors.WithStackTrace(err)
+			}
+			items = append(items, i)
+		}
+	}
+	if err := result.Close(ctx); err != nil {
+		return nil, xerrors.WithStackTrace(err)
+	}
+	return items, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/tetratelabs/wazero v1.9.0
 	github.com/wasilibs/go-pgquery v0.0.0-20250409022910-10ac41983c07
 	github.com/xeipuuv/gojsonschema v1.2.0
-	github.com/ydb-platform/ydb-go-sdk/v3 v3.108.0
+	github.com/ydb-platform/ydb-go-sdk/v3 v3.115.3
 	github.com/ydb-platform/yql-parsers v0.0.0-20250309001738-7d693911f333
 	golang.org/x/sync v0.13.0
 	google.golang.org/grpc v1.72.0
@@ -48,7 +48,7 @@ require (
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
 	github.com/jackc/pgtype v1.14.0 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
-	github.com/jonboulle/clockwork v0.3.0 // indirect
+	github.com/jonboulle/clockwork v0.5.0 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/ncruces/go-strftime v0.1.9 // indirect
 	github.com/pingcap/errors v0.11.5-0.20240311024730-e056997136bb // indirect

--- a/go.sum
+++ b/go.sum
@@ -146,6 +146,7 @@ github.com/jinzhu/inflection v1.0.0 h1:K317FqzuhWc8YvSVlFMCCUb36O/S9MCKRDI7QkRKD
 github.com/jinzhu/inflection v1.0.0/go.mod h1:h+uFLlag+Qp1Va5pdKtLDYj+kHp5pxUVkryuEj+Srlc=
 github.com/jonboulle/clockwork v0.3.0 h1:9BSCMi8C+0qdApAp4auwX0RkLGUjs956h0EkuQymUhg=
 github.com/jonboulle/clockwork v0.3.0/go.mod h1:Pkfl5aHPm1nk2H9h0bjmnJD/BcgbGXUBGnn1kMkgxc8=
+github.com/jonboulle/clockwork v0.5.0/go.mod h1:3mZlmanh0g2NDKO5TWZVJAfofYk64M7XN3SzBPjZF60=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
@@ -241,6 +242,8 @@ github.com/ydb-platform/ydb-go-genproto v0.0.0-20241112172322-ea1f63298f77 h1:LY
 github.com/ydb-platform/ydb-go-genproto v0.0.0-20241112172322-ea1f63298f77/go.mod h1:Er+FePu1dNUieD+XTMDduGpQuCPssK5Q4BjF+IIXJ3I=
 github.com/ydb-platform/ydb-go-sdk/v3 v3.108.0 h1:TwWSp3gRMcja/hRpOofncLvgxAXCmzpz5cGtmdaoITw=
 github.com/ydb-platform/ydb-go-sdk/v3 v3.108.0/go.mod h1:l5sSv153E18VvYcsmr51hok9Sjc16tEC8AXGbwrk+ho=
+github.com/ydb-platform/ydb-go-sdk/v3 v3.115.3 h1:SFeSK2c+PmiToyNIhr143u+YDzLhl/kboXwKLYDk0O4=
+github.com/ydb-platform/ydb-go-sdk/v3 v3.115.3/go.mod h1:Pp1w2xxUoLQ3NCNAwV7pvDq0TVQOdtAqs+ZiC+i8r14=
 github.com/ydb-platform/yql-parsers v0.0.0-20250309001738-7d693911f333 h1:KFtJwlPdOxWjCKXX0jFJ8k1FlbqbRbUW3k/kYSZX7SA=
 github.com/ydb-platform/yql-parsers v0.0.0-20250309001738-7d693911f333/go.mod h1:vrPJPS8cdPSV568YcXhB4bUwhyV8bmWKqmQ5c5Xi99o=
 github.com/zenazn/goji v0.9.0/go.mod h1:7S9M489iMyHBNxwZnk9/EHS098H4/F6TATF2mIxtB1Q=

--- a/internal/codegen/golang/driver.go
+++ b/internal/codegen/golang/driver.go
@@ -8,6 +8,8 @@ func parseDriver(sqlPackage string) opts.SQLDriver {
 		return opts.SQLDriverPGXV4
 	case opts.SQLPackagePGXV5:
 		return opts.SQLDriverPGXV5
+	case opts.SQLPackageYDBGoSDK:
+		return opts.SQLDriverYDBGoSDK
 	default:
 		return opts.SQLDriverLibPQ
 	}

--- a/internal/codegen/golang/opts/enum.go
+++ b/internal/codegen/golang/opts/enum.go
@@ -8,12 +8,14 @@ const (
 	SQLPackagePGXV4    string = "pgx/v4"
 	SQLPackagePGXV5    string = "pgx/v5"
 	SQLPackageStandard string = "database/sql"
+	SQLPackageYDBGoSDK string = "ydb-go-sdk"
 )
 
 var validPackages = map[string]struct{}{
 	string(SQLPackagePGXV4):    {},
 	string(SQLPackagePGXV5):    {},
 	string(SQLPackageStandard): {},
+	string(SQLPackageYDBGoSDK): {},
 }
 
 func validatePackage(sqlPackage string) error {
@@ -28,6 +30,7 @@ const (
 	SQLDriverPGXV5                      = "github.com/jackc/pgx/v5"
 	SQLDriverLibPQ                      = "github.com/lib/pq"
 	SQLDriverGoSQLDriverMySQL           = "github.com/go-sql-driver/mysql"
+	SQLDriverYDBGoSDK                   = "github.com/ydb-platform/ydb-go-sdk/v3"
 )
 
 var validDrivers = map[string]struct{}{
@@ -35,6 +38,7 @@ var validDrivers = map[string]struct{}{
 	string(SQLDriverPGXV5):            {},
 	string(SQLDriverLibPQ):            {},
 	string(SQLDriverGoSQLDriverMySQL): {},
+	string(SQLDriverYDBGoSDK):         {},
 }
 
 func validateDriver(sqlDriver string) error {
@@ -52,12 +56,18 @@ func (d SQLDriver) IsGoSQLDriverMySQL() bool {
 	return d == SQLDriverGoSQLDriverMySQL
 }
 
+func (d SQLDriver) IsYDBGoSDK() bool {
+	return d == SQLDriverYDBGoSDK
+}
+
 func (d SQLDriver) Package() string {
 	switch d {
 	case SQLDriverPGXV4:
 		return SQLPackagePGXV4
 	case SQLDriverPGXV5:
 		return SQLPackagePGXV5
+	case SQLDriverYDBGoSDK:
+		return SQLPackageYDBGoSDK
 	default:
 		return SQLPackageStandard
 	}

--- a/internal/codegen/golang/result.go
+++ b/internal/codegen/golang/result.go
@@ -336,6 +336,7 @@ var cmdReturnsData = map[string]struct{}{
 	metadata.CmdBatchOne:  {},
 	metadata.CmdMany:      {},
 	metadata.CmdOne:       {},
+	metadata.CmdQueryRows: {},
 }
 
 func putOutColumns(query *plugin.Query) bool {

--- a/internal/codegen/golang/templates/template.tmpl
+++ b/internal/codegen/golang/templates/template.tmpl
@@ -25,6 +25,8 @@ import (
 
 {{if .SQLDriver.IsPGX }}
 	{{- template "dbCodeTemplatePgx" .}}
+{{else if .SQLDriver.IsYDBGoSDK }}
+	{{- template "dbCodeYDB" .}}
 {{else}}
 	{{- template "dbCodeTemplateStd" .}}
 {{end}}
@@ -57,6 +59,8 @@ import (
 {{define "interfaceCode"}}
 	{{if .SQLDriver.IsPGX }}
 		{{- template "interfaceCodePgx" .}}
+	{{else if .SQLDriver.IsYDBGoSDK }}
+		{{- template "interfaceCodeYDB" .}}
 	{{else}}
 		{{- template "interfaceCodeStd" .}}
 	{{end}}
@@ -188,6 +192,8 @@ import (
 {{define "queryCode"}}
 {{if .SQLDriver.IsPGX }}
     {{- template "queryCodePgx" .}}
+{{else if .SQLDriver.IsYDBGoSDK }}
+    {{- template "queryCodeYDB" .}}
 {{else}}
     {{- template "queryCodeStd" .}}
 {{end}}

--- a/internal/codegen/golang/templates/ydb-go-sdk/dbCode.tmpl
+++ b/internal/codegen/golang/templates/ydb-go-sdk/dbCode.tmpl
@@ -1,0 +1,24 @@
+{{define "dbCodeYDB"}}
+type DBTX interface {
+    Exec(ctx context.Context, sql string, opts ...query.ExecuteOption) error
+	Query(ctx context.Context, sql string, opts ...query.ExecuteOption) (query.Result, error)
+    QueryResultSet(ctx context.Context, sql string, opts ...query.ExecuteOption) (query.ClosableResultSet, error)
+	QueryRow(ctx context.Context, sql string, opts ...query.ExecuteOption) (query.Row, error)
+}
+
+{{ if .EmitMethodsWithDBArgument}}
+func New() *Queries {
+	return &Queries{}
+{{- else -}}
+func New(db DBTX) *Queries {
+	return &Queries{db: db}
+{{- end}}
+}
+
+type Queries struct {
+    {{if not .EmitMethodsWithDBArgument}}
+	db DBTX
+    {{end}}
+}
+
+{{end}}

--- a/internal/codegen/golang/templates/ydb-go-sdk/interfaceCode.tmpl
+++ b/internal/codegen/golang/templates/ydb-go-sdk/interfaceCode.tmpl
@@ -1,0 +1,45 @@
+{{define "interfaceCodeYDB"}}
+    type Querier interface {
+    {{- $dbtxParam := .EmitMethodsWithDBArgument -}}
+    {{- range .GoQueries}}
+        {{- if and (eq .Cmd ":one") ($dbtxParam) }}
+            {{range .Comments}}//{{.}}
+            {{end -}}
+            {{.MethodName}}(ctx context.Context, db DBTX, {{if not .Arg.IsEmpty}}{{.Arg.Pair}}, {{end}}opts ...query.ExecuteOption) ({{.Ret.DefineType}}, error)
+        {{- else if eq .Cmd ":one"}}
+            {{range .Comments}}//{{.}}
+            {{end -}}
+            {{.MethodName}}(ctx context.Context, {{if not .Arg.IsEmpty}}{{.Arg.Pair}}, {{end}}opts ...query.ExecuteOption) ({{.Ret.DefineType}}, error)
+        {{- end}}
+        {{- if and (eq .Cmd ":many") ($dbtxParam) }}
+            {{range .Comments}}//{{.}}
+            {{end -}}
+            {{.MethodName}}(ctx context.Context, db DBTX, {{if not .Arg.IsEmpty}}{{.Arg.Pair}}, {{end}}opts ...query.ExecuteOption) ([]{{.Ret.DefineType}}, error)
+        {{- else if eq .Cmd ":many"}}
+            {{range .Comments}}//{{.}}
+            {{end -}}
+            {{.MethodName}}(ctx context.Context, {{if not .Arg.IsEmpty}}{{.Arg.Pair}}, {{end}}opts ...query.ExecuteOption) ([]{{.Ret.DefineType}}, error)
+        {{- end}}
+        {{- if and (eq .Cmd ":exec") ($dbtxParam) }}
+            {{range .Comments}}//{{.}}
+            {{end -}}
+            {{.MethodName}}(ctx context.Context, db DBTX, {{if not .Arg.IsEmpty}}{{.Arg.Pair}}, {{end}}opts ...query.ExecuteOption) error
+        {{- else if eq .Cmd ":exec"}}
+            {{range .Comments}}//{{.}}
+            {{end -}}
+            {{.MethodName}}(ctx context.Context, {{if not .Arg.IsEmpty}}{{.Arg.Pair}}, {{end}}opts ...query.ExecuteOption) error
+        {{- end}}
+        {{- if and (eq .Cmd ":queryrows") ($dbtxParam) }}
+            {{range .Comments}}//{{.}}
+            {{end -}}
+            {{.MethodName}}(ctx context.Context, db DBTX, {{if not .Arg.IsEmpty}}{{.Arg.Pair}}, {{end}}opts ...query.ExecuteOption) ([]Author, error)
+        {{- else if eq .Cmd ":queryrows"}}
+            {{range .Comments}}//{{.}}
+            {{end -}}
+            {{.MethodName}}(ctx context.Context, {{if not .Arg.IsEmpty}}{{.Arg.Pair}}, {{end}}opts ...query.ExecuteOption) ([]Author, error)
+        {{- end}}
+    {{- end}}
+    }
+
+    var _ Querier = (*Queries)(nil)
+{{end}}

--- a/internal/codegen/golang/templates/ydb-go-sdk/queryCode.tmpl
+++ b/internal/codegen/golang/templates/ydb-go-sdk/queryCode.tmpl
@@ -1,0 +1,217 @@
+{{define "queryCodeYDB"}}
+{{range .GoQueries}}
+{{if $.OutputQuery .SourceName}}
+const {{.ConstantName}} = {{$.Q}}-- name: {{.MethodName}} {{.Cmd}}
+{{escape .SQL}}
+{{$.Q}}
+
+{{if .Arg.EmitStruct}}
+type {{.Arg.Type}} struct { {{- range .Arg.UniqueFields}}
+  {{.Name}} {{.Type}} {{if .Tag}}{{$.Q}}{{.Tag}}{{$.Q}}{{end}}
+  {{- end}}
+}
+{{end}}
+
+{{if .Ret.EmitStruct}}
+type {{.Ret.Type}} struct { {{- range .Ret.Struct.Fields}}
+  {{.Name}} {{.Type}} {{if .Tag}}{{$.Q}}{{.Tag}}{{$.Q}}{{end}}
+  {{- end}}
+}
+{{end}}
+
+{{if eq .Cmd ":one"}}
+{{range .Comments}}//{{.}}
+{{end -}}
+func (q *Queries) {{.MethodName}}(ctx context.Context, {{if $.EmitMethodsWithDBArgument}}db DBTX, {{end}}{{if not .Arg.IsEmpty}}{{.Arg.Pair}}, {{end}}opts ...query.ExecuteOption) ({{.Ret.DefineType}}, error) {
+    {{- $dbArg := "q.db" }}{{- if $.EmitMethodsWithDBArgument }}{{- $dbArg = "db" }}{{- end -}}
+    {{- if .Arg.IsEmpty }}
+    row, err := {{$dbArg}}.QueryRow(ctx, {{.ConstantName}}, opts...)
+    {{- else }}
+    row, err := {{$dbArg}}.QueryRow(ctx, {{.ConstantName}},
+        append(opts, query.WithParameters(ydb.ParamsFromMap(map[string]any{ {{.Arg.YDBParamMapEntries}} })))...,
+    )
+    {{- end }}
+    {{- if or (ne .Arg.Pair .Ret.Pair) (ne .Arg.DefineType .Ret.DefineType) }}
+	var {{.Ret.Name}} {{.Ret.Type}}
+	{{- end}}
+    if err != nil {
+        {{- if $.WrapErrors}}
+        return {{.Ret.ReturnName}}, xerrors.WithStackTrace(fmt.Errorf("query {{.MethodName}}: %w", err))
+        {{- else }}
+        return {{.Ret.ReturnName}}, xerrors.WithStackTrace(err)
+        {{- end }}
+    }
+	err = row.Scan({{.Ret.Scan}})
+	{{- if $.WrapErrors}}
+	if err != nil {
+		return {{.Ret.ReturnName}}, xerrors.WithStackTrace(fmt.Errorf("query {{.MethodName}}: %w", err))
+	}
+	{{- else }}
+	if err != nil {
+		return {{.Ret.ReturnName}}, xerrors.WithStackTrace(err)
+	}
+	{{- end}}
+	return {{.Ret.ReturnName}}, nil
+}
+{{end}}
+
+{{if eq .Cmd ":many"}}
+{{range .Comments}}//{{.}}
+{{end -}}
+func (q *Queries) {{.MethodName}}(ctx context.Context, {{if $.EmitMethodsWithDBArgument}}db DBTX, {{end}}{{if not .Arg.IsEmpty}}{{.Arg.Pair}}, {{end}}opts ...query.ExecuteOption) ([]{{.Ret.DefineType}}, error) {
+    {{- $dbArg := "q.db" }}{{- if $.EmitMethodsWithDBArgument }}{{- $dbArg = "db" }}{{- end -}}
+    {{- if .Arg.IsEmpty }}
+    res, err := {{$dbArg}}.QueryResultSet(ctx, {{.ConstantName}}, opts...)
+    {{- else }}
+    res, err := {{$dbArg}}.QueryResultSet(ctx, {{.ConstantName}},
+        append(opts, query.WithParameters(ydb.ParamsFromMap(map[string]any{ {{.Arg.YDBParamMapEntries}} })))...,
+    )
+    {{- end }}
+    if err != nil {
+        {{- if $.WrapErrors}}
+        return nil, xerrors.WithStackTrace(fmt.Errorf("query {{.MethodName}}: %w", err))
+        {{- else }}
+        return nil, xerrors.WithStackTrace(err)
+        {{- end }}
+    }
+    {{- if $.EmitEmptySlices}}
+    items := []{{.Ret.DefineType}}{}
+    {{else}}
+    var items []{{.Ret.DefineType}}
+    {{end -}}
+    for row := range res.Rows(ctx) {
+        var {{.Ret.Name}} {{.Ret.Type}}
+        if err := row.Scan({{.Ret.Scan}}); err != nil {
+            {{- if $.WrapErrors}}
+            return nil, xerrors.WithStackTrace(fmt.Errorf("query {{.MethodName}}: %w", err))
+            {{- else }}
+            return nil, xerrors.WithStackTrace(err)
+            {{- end }}
+        }
+        items = append(items, {{.Ret.ReturnName}})
+    }
+    if err := res.Close(ctx); err != nil {
+        {{- if $.WrapErrors}}
+        return nil, xerrors.WithStackTrace(fmt.Errorf("query {{.MethodName}}: %w", err))
+        {{- else }}
+        return nil, xerrors.WithStackTrace(err)
+        {{- end }}
+    }
+    return items, nil
+}
+{{end}}
+
+{{if eq .Cmd ":exec"}}
+{{range .Comments}}//{{.}}
+{{end -}}
+func (q *Queries) {{.MethodName}}(ctx context.Context, {{if $.EmitMethodsWithDBArgument}}db DBTX, {{end}}{{if not .Arg.IsEmpty}}{{.Arg.Pair}}, {{end}}opts ...query.ExecuteOption) error {
+    {{- $dbArg := "q.db" }}{{- if $.EmitMethodsWithDBArgument }}{{- $dbArg = "db" }}{{- end -}}
+    {{- if .Arg.IsEmpty }}
+    err := {{$dbArg}}.Exec(ctx, {{.ConstantName}}, opts...)
+    {{- else }}
+    err := {{$dbArg}}.Exec(ctx, {{.ConstantName}},
+        append(opts, query.WithParameters(ydb.ParamsFromMap(map[string]any{ {{.Arg.YDBParamMapEntries}} })))...,
+    )
+    {{- end }}
+    if err != nil {
+        {{- if $.WrapErrors }}
+        return xerrors.WithStackTrace(fmt.Errorf("query {{.MethodName}}: %w", err))
+        {{- else }}
+        return xerrors.WithStackTrace(err)
+        {{- end }}
+    }
+    return nil
+}
+{{end}}
+
+{{if eq .Cmd ":execresult"}}
+{{range .Comments}}//{{.}}
+{{end -}}
+func (q *Queries) {{.MethodName}}(ctx context.Context, {{if $.EmitMethodsWithDBArgument}}db DBTX, {{end}}{{if not .Arg.IsEmpty}}{{.Arg.Pair}}, {{end}}opts ...query.ExecuteOption) (query.Result, error) {
+    {{- $dbArg := "q.db" }}{{- if $.EmitMethodsWithDBArgument }}{{- $dbArg = "db" }}{{- end -}}
+    {{- if .Arg.IsEmpty }}
+    result, err := {{$dbArg}}.Query(ctx, {{.ConstantName}}, opts...)
+    {{- else }}
+    result, err := {{$dbArg}}.Query(ctx, {{.ConstantName}},
+        append(opts, query.WithParameters(ydb.ParamsFromMap(map[string]any{ {{.Arg.YDBParamMapEntries}} })))...,
+    )
+    {{- end }}
+    {{- if $.WrapErrors}}
+    if err != nil {
+        return result, xerrors.WithStackTrace(fmt.Errorf("query {{.MethodName}}: %w", err))
+    }
+    {{- else }}
+    if err != nil {
+        return result, xerrors.WithStackTrace(err)
+    }
+    {{- end}}
+    return result, nil
+}
+{{end}}
+
+{{if eq .Cmd ":queryrows"}}
+{{range .Comments}}//{{.}}
+{{end -}}
+func (q *Queries) {{.MethodName}}(ctx context.Context, {{if $.EmitMethodsWithDBArgument}}db DBTX, {{end}}{{if not .Arg.IsEmpty}}{{.Arg.Pair}}, {{end}}opts ...query.ExecuteOption) ([]{{.Ret.DefineType}}, error) {
+    {{- $dbArg := "q.db" }}{{- if $.EmitMethodsWithDBArgument }}{{- $dbArg = "db" }}{{- end -}}
+    {{- if .Arg.IsEmpty }}
+    result, err := {{$dbArg}}.Query(ctx, {{.ConstantName}}, opts...)
+    {{- else }}
+    result, err := {{$dbArg}}.Query(ctx, {{.ConstantName}},
+        append(opts, query.WithParameters(ydb.ParamsFromMap(map[string]any{ {{.Arg.YDBParamMapEntries}} })))...,
+    )
+    {{- end }}
+    if err != nil {
+        {{- if $.WrapErrors}}
+        return nil, xerrors.WithStackTrace(fmt.Errorf("query {{.MethodName}}: %w", err))
+        {{- else }}
+        return nil, xerrors.WithStackTrace(err)
+        {{- end }}
+    }
+    {{- if $.EmitEmptySlices}}
+    items := []{{.Ret.DefineType}}{}
+    {{else}}
+    var items []{{.Ret.DefineType}}
+    {{end -}}
+    
+    for set, err := range result.ResultSets(ctx) {
+		if err != nil {
+			{{- if $.WrapErrors}}
+            return nil, xerrors.WithStackTrace(fmt.Errorf("query {{.MethodName}}: %w", err))
+            {{- else }}
+            return nil, xerrors.WithStackTrace(err)
+            {{- end }}
+		}
+		for row, err := range set.Rows(ctx) {
+			if err != nil {
+				{{- if $.WrapErrors}}
+                return nil, xerrors.WithStackTrace(fmt.Errorf("query {{.MethodName}}: %w", err))
+                {{- else }}
+                return nil, xerrors.WithStackTrace(err)
+                {{- end }}
+			}
+			var {{.Ret.Name}} {{.Ret.Type}}
+			if err := row.Scan({{.Ret.Scan}}); err != nil {
+                {{- if $.WrapErrors}}
+                return nil, xerrors.WithStackTrace(fmt.Errorf("query {{.MethodName}}: %w", err))
+                {{- else }}
+                return nil, xerrors.WithStackTrace(err)
+                {{- end }}
+            }
+			items = append(items, i)
+		}
+	}
+	if err := result.Close(ctx); err != nil {
+		{{- if $.WrapErrors}}
+        return nil, xerrors.WithStackTrace(fmt.Errorf("query {{.MethodName}}: %w", err))
+        {{- else }}
+        return nil, xerrors.WithStackTrace(err)
+        {{- end }}
+	}
+	return items, nil
+}
+{{end}}
+
+{{end}}
+{{end}}
+{{end}}

--- a/internal/metadata/meta.go
+++ b/internal/metadata/meta.go
@@ -37,6 +37,7 @@ const (
 	CmdBatchExec  = ":batchexec"
 	CmdBatchMany  = ":batchmany"
 	CmdBatchOne   = ":batchone"
+	CmdQueryRows  = ":queryrows"
 )
 
 // A query name must be a valid Go identifier
@@ -106,7 +107,7 @@ func ParseQueryNameAndType(t string, commentStyle CommentSyntax) (string, string
 		queryName := part[2]
 		queryType := strings.TrimSpace(part[3])
 		switch queryType {
-		case CmdOne, CmdMany, CmdExec, CmdExecResult, CmdExecRows, CmdExecLastId, CmdCopyFrom, CmdBatchExec, CmdBatchMany, CmdBatchOne:
+		case CmdOne, CmdMany, CmdExec, CmdExecResult, CmdExecRows, CmdExecLastId, CmdCopyFrom, CmdBatchExec, CmdBatchMany, CmdBatchOne, CmdQueryRows:
 		default:
 			return "", "", fmt.Errorf("invalid query type: %s", queryType)
 		}


### PR DESCRIPTION
See (#4)

Added native ydb-go-sdk generation support for YDB engine. Supported :queryrows comment to add support for `.Query(...)` method.