### PR TITLE
Expanding YQL Syntax support in sqlc engine

### DIFF
--- a/internal/engine/ydb/catalog_tests/delete_test.go
+++ b/internal/engine/ydb/catalog_tests/delete_test.go
@@ -145,6 +145,7 @@ func TestDelete(t *testing.T) {
 							},
 						},
 						OnSelectStmt: &ast.SelectStmt{
+							DistinctClause: &ast.List{},
 							TargetList: &ast.List{
 								Items: []ast.Node{
 									&ast.ResTarget{
@@ -153,7 +154,12 @@ func TestDelete(t *testing.T) {
 									},
 								},
 							},
-							FromClause: &ast.List{},
+							FromClause:    &ast.List{},
+							GroupClause:    &ast.List{},
+							WindowClause:   &ast.List{},
+							ValuesLists:    &ast.List{},
+							SortClause:     &ast.List{},
+							LockingClause:  &ast.List{},
 						},
 						ReturningList: &ast.List{
 							Items: []ast.Node{

--- a/internal/engine/ydb/catalog_tests/delete_test.go
+++ b/internal/engine/ydb/catalog_tests/delete_test.go
@@ -101,6 +101,7 @@ func TestDelete(t *testing.T) {
 							},
 						},
 						OnSelectStmt: &ast.SelectStmt{
+							DistinctClause: &ast.List{},
 							ValuesLists: &ast.List{
 								Items: []ast.Node{
 									&ast.List{
@@ -110,8 +111,12 @@ func TestDelete(t *testing.T) {
 									},
 								},
 							},
-							FromClause: &ast.List{},
-							TargetList: &ast.List{},
+							FromClause:    &ast.List{},
+							TargetList:    &ast.List{},
+							GroupClause:   &ast.List{},
+							WindowClause:  &ast.List{},
+							SortClause:    &ast.List{},
+							LockingClause: &ast.List{},
 						},
 						ReturningList: &ast.List{
 							Items: []ast.Node{
@@ -155,11 +160,11 @@ func TestDelete(t *testing.T) {
 								},
 							},
 							FromClause:    &ast.List{},
-							GroupClause:    &ast.List{},
-							WindowClause:   &ast.List{},
-							ValuesLists:    &ast.List{},
-							SortClause:     &ast.List{},
-							LockingClause:  &ast.List{},
+							GroupClause:   &ast.List{},
+							WindowClause:  &ast.List{},
+							ValuesLists:   &ast.List{},
+							SortClause:    &ast.List{},
+							LockingClause: &ast.List{},
 						},
 						ReturningList: &ast.List{
 							Items: []ast.Node{

--- a/internal/engine/ydb/catalog_tests/insert_test.go
+++ b/internal/engine/ydb/catalog_tests/insert_test.go
@@ -28,6 +28,7 @@ func TestInsert(t *testing.T) {
 							},
 						},
 						SelectStmt: &ast.SelectStmt{
+							DistinctClause: &ast.List{},
 							ValuesLists: &ast.List{
 								Items: []ast.Node{
 									&ast.List{
@@ -40,6 +41,10 @@ func TestInsert(t *testing.T) {
 							},
 							TargetList: &ast.List{},
 							FromClause: &ast.List{},
+							GroupClause: &ast.List{},
+							WindowClause: &ast.List{},
+							SortClause: &ast.List{},
+							LockingClause: &ast.List{},
 						},
 						OnConflictClause: &ast.OnConflictClause{},
 						ReturningList: &ast.List{
@@ -68,6 +73,7 @@ func TestInsert(t *testing.T) {
 							},
 						},
 						SelectStmt: &ast.SelectStmt{
+							DistinctClause: &ast.List{},
 							ValuesLists: &ast.List{
 								Items: []ast.Node{
 									&ast.List{
@@ -79,6 +85,10 @@ func TestInsert(t *testing.T) {
 							},
 							TargetList: &ast.List{},
 							FromClause: &ast.List{},
+							GroupClause: &ast.List{},
+							WindowClause: &ast.List{},
+							SortClause: &ast.List{},
+							LockingClause: &ast.List{},
 						},
 						OnConflictClause: &ast.OnConflictClause{
 							Action: ast.OnConflictAction_INSERT_OR_IGNORE,
@@ -106,7 +116,16 @@ func TestInsert(t *testing.T) {
 					Stmt: &ast.InsertStmt{
 						Relation:         &ast.RangeVar{Relname: strPtr("users")},
 						Cols:             &ast.List{Items: []ast.Node{&ast.ResTarget{Name: strPtr("id")}}},
-						SelectStmt:       &ast.SelectStmt{ValuesLists: &ast.List{Items: []ast.Node{&ast.List{Items: []ast.Node{&ast.A_Const{Val: &ast.Integer{Ival: 4}}}}}}, TargetList: &ast.List{}, FromClause: &ast.List{}},
+						SelectStmt: &ast.SelectStmt{
+							DistinctClause: &ast.List{},
+							ValuesLists: &ast.List{Items: []ast.Node{&ast.List{Items: []ast.Node{&ast.A_Const{Val: &ast.Integer{Ival: 4}}}}}},
+							TargetList: &ast.List{},
+							FromClause: &ast.List{},
+							GroupClause: &ast.List{},
+							WindowClause: &ast.List{},
+							SortClause: &ast.List{},
+							LockingClause: &ast.List{},
+						},
 						OnConflictClause: &ast.OnConflictClause{Action: ast.OnConflictAction_UPSERT},
 						ReturningList:    &ast.List{Items: []ast.Node{&ast.ResTarget{Val: &ast.ColumnRef{Fields: &ast.List{Items: []ast.Node{&ast.String{Str: "id"}}}}, Indirection: &ast.List{}}}},
 					},

--- a/internal/engine/ydb/catalog_tests/select_test.go
+++ b/internal/engine/ydb/catalog_tests/select_test.go
@@ -25,6 +25,7 @@ func TestSelect(t *testing.T) {
 			expected: &ast.Statement{
 				Raw: &ast.RawStmt{
 					Stmt: &ast.SelectStmt{
+						DistinctClause: &ast.List{},
 						TargetList: &ast.List{
 							Items: []ast.Node{
 								&ast.ResTarget{
@@ -34,7 +35,12 @@ func TestSelect(t *testing.T) {
 								},
 							},
 						},
-						FromClause: &ast.List{},
+						FromClause:    &ast.List{},
+						GroupClause:   &ast.List{},
+						WindowClause:  &ast.List{},
+						ValuesLists:   &ast.List{},
+						SortClause:    &ast.List{},
+						LockingClause: &ast.List{},
 					},
 				},
 			},
@@ -44,6 +50,7 @@ func TestSelect(t *testing.T) {
 			expected: &ast.Statement{
 				Raw: &ast.RawStmt{
 					Stmt: &ast.SelectStmt{
+						DistinctClause: &ast.List{},
 						TargetList: &ast.List{
 							Items: []ast.Node{
 								&ast.ResTarget{
@@ -53,7 +60,12 @@ func TestSelect(t *testing.T) {
 								},
 							},
 						},
-						FromClause: &ast.List{},
+						FromClause:    &ast.List{},
+						GroupClause:   &ast.List{},
+						WindowClause:  &ast.List{},
+						ValuesLists:   &ast.List{},
+						SortClause:    &ast.List{},
+						LockingClause: &ast.List{},
 					},
 				},
 			},
@@ -63,6 +75,7 @@ func TestSelect(t *testing.T) {
 			expected: &ast.Statement{
 				Raw: &ast.RawStmt{
 					Stmt: &ast.SelectStmt{
+						DistinctClause: &ast.List{},
 						TargetList: &ast.List{
 							Items: []ast.Node{
 								&ast.ResTarget{
@@ -72,7 +85,12 @@ func TestSelect(t *testing.T) {
 								},
 							},
 						},
-						FromClause: &ast.List{},
+						FromClause:    &ast.List{},
+						GroupClause:   &ast.List{},
+						WindowClause:  &ast.List{},
+						ValuesLists:   &ast.List{},
+						SortClause:    &ast.List{},
+						LockingClause: &ast.List{},
 					},
 				},
 			},
@@ -82,6 +100,7 @@ func TestSelect(t *testing.T) {
 			expected: &ast.Statement{
 				Raw: &ast.RawStmt{
 					Stmt: &ast.SelectStmt{
+						DistinctClause: &ast.List{},
 						TargetList: &ast.List{
 							Items: []ast.Node{
 								&ast.ResTarget{
@@ -91,7 +110,12 @@ func TestSelect(t *testing.T) {
 								},
 							},
 						},
-						FromClause: &ast.List{},
+						FromClause:    &ast.List{},
+						GroupClause:   &ast.List{},
+						WindowClause:  &ast.List{},
+						ValuesLists:   &ast.List{},
+						SortClause:    &ast.List{},
+						LockingClause: &ast.List{},
 					},
 				},
 			},
@@ -101,6 +125,7 @@ func TestSelect(t *testing.T) {
 			expected: &ast.Statement{
 				Raw: &ast.RawStmt{
 					Stmt: &ast.SelectStmt{
+						DistinctClause: &ast.List{},
 						TargetList: &ast.List{
 							Items: []ast.Node{
 								&ast.ResTarget{
@@ -108,7 +133,12 @@ func TestSelect(t *testing.T) {
 								},
 							},
 						},
-						FromClause: &ast.List{},
+						FromClause:    &ast.List{},
+						GroupClause:   &ast.List{},
+						WindowClause:  &ast.List{},
+						ValuesLists:   &ast.List{},
+						SortClause:    &ast.List{},
+						LockingClause: &ast.List{},
 					},
 				},
 			},
@@ -118,6 +148,7 @@ func TestSelect(t *testing.T) {
 			expected: &ast.Statement{
 				Raw: &ast.RawStmt{
 					Stmt: &ast.SelectStmt{
+						DistinctClause: &ast.List{},
 						TargetList: &ast.List{
 							Items: []ast.Node{
 								&ast.ResTarget{
@@ -127,7 +158,12 @@ func TestSelect(t *testing.T) {
 								},
 							},
 						},
-						FromClause: &ast.List{},
+						FromClause:    &ast.List{},
+						GroupClause:   &ast.List{},
+						WindowClause:  &ast.List{},
+						ValuesLists:   &ast.List{},
+						SortClause:    &ast.List{},
+						LockingClause: &ast.List{},
 					},
 				},
 			},
@@ -137,6 +173,7 @@ func TestSelect(t *testing.T) {
 			expected: &ast.Statement{
 				Raw: &ast.RawStmt{
 					Stmt: &ast.SelectStmt{
+						DistinctClause: &ast.List{},
 						TargetList: &ast.List{
 							Items: []ast.Node{
 								&ast.ResTarget{
@@ -166,7 +203,12 @@ func TestSelect(t *testing.T) {
 								},
 							},
 						},
-						FromClause: &ast.List{},
+						FromClause:    &ast.List{},
+						GroupClause:   &ast.List{},
+						WindowClause:  &ast.List{},
+						ValuesLists:   &ast.List{},
+						SortClause:    &ast.List{},
+						LockingClause: &ast.List{},
 					},
 				},
 			},
@@ -178,6 +220,7 @@ func TestSelect(t *testing.T) {
 			expected: &ast.Statement{
 				Raw: &ast.RawStmt{
 					Stmt: &ast.SelectStmt{
+						DistinctClause: &ast.List{},
 						TargetList: &ast.List{
 							Items: []ast.Node{
 								&ast.ResTarget{
@@ -198,6 +241,11 @@ func TestSelect(t *testing.T) {
 								},
 							},
 						},
+						GroupClause:   &ast.List{},
+						WindowClause:  &ast.List{},
+						ValuesLists:   &ast.List{},
+						SortClause:    &ast.List{},
+						LockingClause: &ast.List{},
 					},
 				},
 			},
@@ -207,6 +255,7 @@ func TestSelect(t *testing.T) {
 			expected: &ast.Statement{
 				Raw: &ast.RawStmt{
 					Stmt: &ast.SelectStmt{
+						DistinctClause: &ast.List{},
 						TargetList: &ast.List{
 							Items: []ast.Node{
 								&ast.ResTarget{
@@ -228,6 +277,11 @@ func TestSelect(t *testing.T) {
 								},
 							},
 						},
+						GroupClause:   &ast.List{},
+						WindowClause:  &ast.List{},
+						ValuesLists:   &ast.List{},
+						SortClause:    &ast.List{},
+						LockingClause: &ast.List{},
 					},
 				},
 			},
@@ -237,6 +291,7 @@ func TestSelect(t *testing.T) {
 			expected: &ast.Statement{
 				Raw: &ast.RawStmt{
 					Stmt: &ast.SelectStmt{
+						DistinctClause: &ast.List{},
 						TargetList: &ast.List{
 							Items: []ast.Node{
 								&ast.ResTarget{
@@ -259,6 +314,11 @@ func TestSelect(t *testing.T) {
 								},
 							},
 						},
+						GroupClause:   &ast.List{},
+						WindowClause:  &ast.List{},
+						ValuesLists:   &ast.List{},
+						SortClause:    &ast.List{},
+						LockingClause: &ast.List{},
 					},
 				},
 			},
@@ -268,6 +328,7 @@ func TestSelect(t *testing.T) {
 			expected: &ast.Statement{
 				Raw: &ast.RawStmt{
 					Stmt: &ast.SelectStmt{
+						DistinctClause: &ast.List{},
 						TargetList: &ast.List{
 							Items: []ast.Node{
 								&ast.ResTarget{
@@ -307,6 +368,11 @@ func TestSelect(t *testing.T) {
 								},
 							},
 						},
+						GroupClause:   &ast.List{},
+						WindowClause:  &ast.List{},
+						ValuesLists:   &ast.List{},
+						SortClause:    &ast.List{},
+						LockingClause: &ast.List{},
 					},
 				},
 			},
@@ -316,6 +382,7 @@ func TestSelect(t *testing.T) {
 			expected: &ast.Statement{
 				Raw: &ast.RawStmt{
 					Stmt: &ast.SelectStmt{
+						DistinctClause: &ast.List{},
 						TargetList: &ast.List{
 							Items: []ast.Node{
 								&ast.ResTarget{
@@ -362,6 +429,287 @@ func TestSelect(t *testing.T) {
 								Val: &ast.Integer{Ival: 30},
 							},
 						},
+						GroupClause:   &ast.List{},
+						WindowClause:  &ast.List{},
+						ValuesLists:   &ast.List{},
+						SortClause:    &ast.List{},
+						LockingClause: &ast.List{},
+					},
+				},
+			},
+		},
+		{
+			stmt: `(SELECT 1) UNION ALL (SELECT 2)`,
+			expected: &ast.Statement{
+				Raw: &ast.RawStmt{
+					Stmt: &ast.SelectStmt{
+						DistinctClause: &ast.List{},
+						TargetList:     &ast.List{},
+						FromClause:     &ast.List{},
+						GroupClause:    &ast.List{},
+						WindowClause:   &ast.List{},
+						ValuesLists:    &ast.List{},
+						SortClause:     &ast.List{},
+						LockingClause:  &ast.List{},
+						Op:             ast.Union,
+						All:            true,
+						Larg: &ast.SelectStmt{
+							DistinctClause: &ast.List{},
+							TargetList: &ast.List{
+								Items: []ast.Node{
+									&ast.ResTarget{
+										Val: &ast.A_Const{
+											Val: &ast.Integer{Ival: 1},
+										},
+									},
+								},
+							},
+							FromClause:    &ast.List{},
+							GroupClause:   &ast.List{},
+							WindowClause:  &ast.List{},
+							ValuesLists:   &ast.List{},
+							SortClause:    &ast.List{},
+							LockingClause: &ast.List{},
+						},
+						Rarg: &ast.SelectStmt{
+							DistinctClause: &ast.List{},
+							TargetList: &ast.List{
+								Items: []ast.Node{
+									&ast.ResTarget{
+										Val: &ast.A_Const{
+											Val: &ast.Integer{Ival: 2},
+										},
+									},
+								},
+							},
+							FromClause:    &ast.List{},
+							GroupClause:   &ast.List{},
+							WindowClause:  &ast.List{},
+							ValuesLists:   &ast.List{},
+							SortClause:    &ast.List{},
+							LockingClause: &ast.List{},
+						},
+					},
+				},
+			},
+		},
+		{
+			stmt: `SELECT id FROM users ORDER BY id DESC`,
+			expected: &ast.Statement{
+				Raw: &ast.RawStmt{
+					Stmt: &ast.SelectStmt{
+						DistinctClause: &ast.List{},
+						TargetList: &ast.List{
+							Items: []ast.Node{
+								&ast.ResTarget{
+									Val: &ast.ColumnRef{
+										Fields: &ast.List{
+											Items: []ast.Node{
+												&ast.String{Str: "id"},
+											},
+										},
+									},
+								},
+							},
+						},
+						FromClause: &ast.List{
+							Items: []ast.Node{
+								&ast.RangeVar{
+									Relname: strPtr("users"),
+								},
+							},
+						},
+						GroupClause:   &ast.List{},
+						WindowClause:  &ast.List{},
+						ValuesLists:   &ast.List{},
+						LockingClause: &ast.List{},
+						SortClause: &ast.List{
+							Items: []ast.Node{
+								&ast.SortBy{
+									Node: &ast.ColumnRef{
+										Fields: &ast.List{
+											Items: []ast.Node{
+												&ast.String{Str: "id"},
+											},
+										},
+									},
+									SortbyDir: ast.SortByDirDesc,
+									UseOp:     &ast.List{},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			stmt: `SELECT id FROM users LIMIT 10 OFFSET 5`,
+			expected: &ast.Statement{
+				Raw: &ast.RawStmt{
+					Stmt: &ast.SelectStmt{
+						DistinctClause: &ast.List{},
+						TargetList: &ast.List{
+							Items: []ast.Node{
+								&ast.ResTarget{
+									Val: &ast.ColumnRef{
+										Fields: &ast.List{
+											Items: []ast.Node{
+												&ast.String{Str: "id"},
+											},
+										},
+									},
+								},
+							},
+						},
+						FromClause: &ast.List{
+							Items: []ast.Node{
+								&ast.RangeVar{
+									Relname: strPtr("users"),
+								},
+							},
+						},
+						GroupClause:   &ast.List{},
+						WindowClause:  &ast.List{},
+						ValuesLists:   &ast.List{},
+						SortClause:    &ast.List{},
+						LockingClause: &ast.List{},
+						LimitCount: &ast.A_Const{
+							Val: &ast.Integer{Ival: 10},
+						},
+						LimitOffset: &ast.A_Const{
+							Val: &ast.Integer{Ival: 5},
+						},
+					},
+				},
+			},
+		},
+		{
+			stmt: `SELECT id FROM users WHERE id > 10 GROUP BY id HAVING id > 10`,
+			expected: &ast.Statement{
+				Raw: &ast.RawStmt{
+					Stmt: &ast.SelectStmt{
+						DistinctClause: &ast.List{},
+						TargetList: &ast.List{
+							Items: []ast.Node{
+								&ast.ResTarget{
+									Val: &ast.ColumnRef{
+										Fields: &ast.List{
+											Items: []ast.Node{
+												&ast.String{Str: "id"},
+											},
+										},
+									},
+								},
+							},
+						},
+						FromClause: &ast.List{
+							Items: []ast.Node{
+								&ast.RangeVar{
+									Relname: strPtr("users"),
+								},
+							},
+						},
+						GroupClause:   &ast.List{
+							Items: []ast.Node{
+								&ast.ColumnRef{
+									Fields: &ast.List{
+										Items: []ast.Node{
+											&ast.String{Str: "id"},
+										},
+									},
+								},
+							},
+						},
+						WindowClause:  &ast.List{},
+						ValuesLists:   &ast.List{},
+						SortClause:    &ast.List{},
+						LockingClause: &ast.List{},
+						WhereClause: &ast.A_Expr{
+							Name: &ast.List{
+								Items: []ast.Node{
+									&ast.String{Str: ">"},
+								},
+							},
+							Lexpr: &ast.ColumnRef{
+								Fields: &ast.List{
+									Items: []ast.Node{
+										&ast.String{Str: "id"},
+									},
+								},
+							},
+							Rexpr: &ast.A_Const{
+								Val: &ast.Integer{Ival: 10},
+							},
+						},
+						HavingClause: &ast.A_Expr{
+							Name: &ast.List{
+								Items: []ast.Node{
+									&ast.String{Str: ">"},
+								},
+							},
+							Lexpr: &ast.ColumnRef{
+								Fields: &ast.List{
+									Items: []ast.Node{
+										&ast.String{Str: "id"},
+									},
+								},
+							},
+							Rexpr: &ast.A_Const{
+								Val: &ast.Integer{Ival: 10},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			stmt: `SELECT id FROM users GROUP BY ROLLUP (id)`,
+			expected: &ast.Statement{
+				Raw: &ast.RawStmt{
+					Stmt: &ast.SelectStmt{
+						DistinctClause: &ast.List{},
+						TargetList: &ast.List{
+							Items: []ast.Node{
+								&ast.ResTarget{
+									Val: &ast.ColumnRef{
+										Fields: &ast.List{
+											Items: []ast.Node{
+												&ast.String{Str: "id"},
+											},
+										},
+									},
+								},
+							},
+						},
+						FromClause: &ast.List{
+							Items: []ast.Node{
+								&ast.RangeVar{
+									Relname: strPtr("users"),
+								},
+							},
+						},
+						GroupClause: &ast.List{
+							Items: []ast.Node{
+								&ast.GroupingSet{
+									Kind: 1, // T_GroupingSet: ROLLUP
+									Content: &ast.List{
+										Items: []ast.Node{
+											&ast.ColumnRef{
+												Fields: &ast.List{
+													Items: []ast.Node{
+														&ast.String{Str: "id"},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+						WindowClause:  &ast.List{},
+						ValuesLists:   &ast.List{},
+						SortClause:    &ast.List{},
+						LockingClause: &ast.List{},
 					},
 				},
 			},
@@ -382,12 +730,12 @@ func TestSelect(t *testing.T) {
 
 			diff := cmp.Diff(tc.expected, &stmts[0],
 				cmpopts.IgnoreFields(ast.RawStmt{}, "StmtLocation", "StmtLen"),
-				// cmpopts.IgnoreFields(ast.SelectStmt{}, "Location"),
 				cmpopts.IgnoreFields(ast.A_Const{}, "Location"),
 				cmpopts.IgnoreFields(ast.ResTarget{}, "Location"),
 				cmpopts.IgnoreFields(ast.ColumnRef{}, "Location"),
 				cmpopts.IgnoreFields(ast.A_Expr{}, "Location"),
 				cmpopts.IgnoreFields(ast.RangeVar{}, "Location"),
+				cmpopts.IgnoreFields(ast.SortBy{}, "Location"),
 			)
 			if diff != "" {
 				t.Errorf("AST mismatch for %q (-expected +got):\n%s", tc.stmt, diff)

--- a/internal/engine/ydb/catalog_tests/update_test.go
+++ b/internal/engine/ydb/catalog_tests/update_test.go
@@ -121,6 +121,7 @@ func TestUpdate(t *testing.T) {
 							},
 						},
 						OnSelectStmt: &ast.SelectStmt{
+							DistinctClause: &ast.List{},
 							ValuesLists: &ast.List{
 								Items: []ast.Node{
 									&ast.List{
@@ -132,6 +133,10 @@ func TestUpdate(t *testing.T) {
 							},
 							FromClause: &ast.List{},
 							TargetList: &ast.List{},
+							GroupClause: &ast.List{},
+							WindowClause: &ast.List{},
+							SortClause: &ast.List{},
+							LockingClause: &ast.List{},
 						},
 						ReturningList: &ast.List{
 							Items: []ast.Node{

--- a/internal/engine/ydb/convert.go
+++ b/internal/engine/ydb/convert.go
@@ -2680,6 +2680,9 @@ func (c *cc) convert(node node) ast.Node {
 
 	case *parser.Alter_table_stmtContext:
 		return c.convertAlter_table_stmtContext(n)
+	
+	case *parser.Do_stmtContext:
+		return c.convertDo_stmtContext(n)
 
 	case *parser.Drop_table_stmtContext:
 		return c.convertDrop_table_stmtContext(n)

--- a/internal/engine/ydb/convert.go
+++ b/internal/engine/ydb/convert.go
@@ -634,12 +634,9 @@ func (c *cc) convertDelete_stmtContext(n *parser.Delete_stmtContext) ast.Node {
 		if valSource != nil {
 			switch {
 			case valSource.Values_stmt() != nil:
-				source = &ast.SelectStmt{
-					ValuesLists: c.convert(valSource.Values_stmt()).(*ast.List),
-					FromClause:  &ast.List{},
-					TargetList:  &ast.List{},
-				}
-
+				stmt := emptySelectStmt()
+				stmt.ValuesLists = c.convert(valSource.Values_stmt()).(*ast.List)
+				source = stmt
 			case valSource.Select_stmt() != nil:
 				source = c.convert(valSource.Select_stmt())
 			}
@@ -829,12 +826,9 @@ func (c *cc) convertUpdate_stmtContext(n *parser.Update_stmtContext) ast.Node {
 		if valSource != nil {
 			switch {
 			case valSource.Values_stmt() != nil:
-				source = &ast.SelectStmt{
-					ValuesLists: c.convert(valSource.Values_stmt()).(*ast.List),
-					FromClause:  &ast.List{},
-					TargetList:  &ast.List{},
-				}
-
+				stmt := emptySelectStmt()
+				stmt.ValuesLists = c.convert(valSource.Values_stmt()).(*ast.List)
+				source = stmt
 			case valSource.Select_stmt() != nil:
 				source = c.convert(valSource.Select_stmt())
 			}
@@ -902,12 +896,9 @@ func (c *cc) convertInto_table_stmtContext(n *parser.Into_table_stmtContext) ast
 		if valSource != nil {
 			switch {
 			case valSource.Values_stmt() != nil:
-				source = &ast.SelectStmt{
-					ValuesLists: c.convert(valSource.Values_stmt()).(*ast.List),
-					FromClause:  &ast.List{},
-					TargetList:  &ast.List{},
-				}
-
+				stmt := emptySelectStmt()
+				stmt.ValuesLists = c.convert(valSource.Values_stmt()).(*ast.List)
+				source = stmt
 			case valSource.Select_stmt() != nil:
 				source = c.convert(valSource.Select_stmt())
 			}
@@ -1025,20 +1016,12 @@ func (c *cc) convertSelectStmtContext(n *parser.Select_stmtContext) ast.Node {
 			}
 			all = so.ALL() != nil
 		}
-		left = &ast.SelectStmt{
-			DistinctClause: &ast.List{},
-			TargetList:     &ast.List{},
-			FromClause:     &ast.List{},
-			GroupClause:    &ast.List{},
-			WindowClause:   &ast.List{},
-			ValuesLists:    &ast.List{},
-			SortClause:     &ast.List{},
-			LockingClause:  &ast.List{},
-			Op:             op,
-			All:            all,
-			Larg:           left,
-			Rarg:           right,
-		}
+		larg := left
+		left = emptySelectStmt()
+		left.Op = op
+		left.All = all
+		left.Larg = larg
+		left.Rarg = right
 	}
 
 	return left
@@ -1087,16 +1070,7 @@ func (c *cc) convertSelectKindParenthesis(n parser.ISelect_kind_parenthesisConte
 }
 
 func (c *cc) convertSelectCoreContext(n parser.ISelect_coreContext) ast.Node {
-	stmt := &ast.SelectStmt{
-		DistinctClause: &ast.List{},
-		TargetList:     &ast.List{},
-		FromClause:     &ast.List{},
-		GroupClause:    &ast.List{},
-		WindowClause:   &ast.List{},
-		ValuesLists:    &ast.List{},
-		SortClause:     &ast.List{},
-		LockingClause:  &ast.List{},
-	}
+	stmt := emptySelectStmt()
 	if n.Opt_set_quantifier() != nil {
 		oq := n.Opt_set_quantifier()
 		if oq.DISTINCT() != nil {

--- a/internal/engine/ydb/utils.go
+++ b/internal/engine/ydb/utils.go
@@ -206,3 +206,16 @@ func byteOffsetFromRuneIndex(s string, runeIndex int) int {
 	}
 	return bytePos
 }
+
+func emptySelectStmt() *ast.SelectStmt {
+	return &ast.SelectStmt{
+		DistinctClause: &ast.List{},
+		TargetList:     &ast.List{},
+		FromClause:     &ast.List{},
+		GroupClause:    &ast.List{},
+		WindowClause:   &ast.List{},
+		ValuesLists:    &ast.List{},
+		SortClause:     &ast.List{},
+		LockingClause:  &ast.List{},
+	}
+}

--- a/internal/engine/ydb/utils.go
+++ b/internal/engine/ydb/utils.go
@@ -85,7 +85,7 @@ func parseIdOrType(ctx parser.IId_or_typeContext) string {
 	}
 	Id := ctx.(*parser.Id_or_typeContext)
 	if Id.Id() != nil {
-		return identifier(parseIdTable(Id.Id()))
+		return identifier(parseId(Id.Id()))
 	}
 
 	return ""
@@ -112,11 +112,23 @@ func parseAnIdSchema(ctx parser.IAn_id_schemaContext) string {
 	return ""
 }
 
-func parseIdTable(ctx parser.IIdContext) string {
+func parseId(ctx parser.IIdContext) string {
 	if ctx == nil {
 		return ""
 	}
 	return ctx.GetText()
+}
+
+func parseAnIdTable(ctx parser.IAn_id_tableContext) string {
+	if ctx == nil {
+		return ""
+	}
+	if id := ctx.Id_table(); id != nil {
+		return id.GetText()
+	} else if str := ctx.STRING_VALUE(); str != nil {
+		return str.GetText()
+	}
+	return ""
 }
 
 func parseIntegerValue(text string) (int64, error) {


### PR DESCRIPTION
- [x] `pragma_stmt`
- [x] `select_stmt`
- [ ] `named_nodes_stmt`
- [x] `create_table_stmt`
- [x] `drop_table_stmt`
- [x] `use_stmt`
- [x] `into_table_stmt`
- [x] `commit_stmt`
- [x] `update_stmt`
- [x] `delete_stmt`
- [x] `rollback_stmt`
- [ ] `declare_stmt`
- [ ] `import_stmt`
- [ ] `export_stmt`
- [x] `alter_table_stmt` (upd)
- [ ] `alter_external_table_stmt`
- [x] `do_stmt` (upd)
- [ ] `define_action_or_subquery_stmt`
- [ ] `if_stmt`
- [ ] `for_stmt`
- [x] `values_stmt`
- [x] `create_user_stmt`
- [x] `alter_user_stmt`
- [x] `create_group_stmt`
- [x] `alter_group_stmt`
- [x] `drop_role_stmt`
- [ ] `create_object_stmt`
- [ ] `alter_object_stmt`
- [ ] `drop_object_stmt`
- [ ] `create_external_data_source_stmt`
- [ ] `alter_external_data_source_stmt`
- [ ] `drop_external_data_source_stmt`
- [ ] `create_replication_stmt`
- [ ] `drop_replication_stmt`
- [ ] `create_topic_stmt`
- [ ] `alter_topic_stmt`
- [ ] `drop_topic_stmt`
- [ ] `grant_permissions_stmt`
- [ ] `revoke_permissions_stmt`
- [ ] `alter_table_store_stmt`
- [ ] `upsert_object_stmt`
- [ ] `create_view_stmt`
- [ ] `drop_view_stmt`
- [ ] `alter_replication_stmt`
- [ ] `create_resource_pool_stmt`
- [ ] `alter_resource_pool_stmt`
- [ ] `drop_resource_pool_stmt`
- [ ] `create_backup_collection_stmt`
- [ ] `alter_backup_collection_stmt`
- [ ] `drop_backup_collection_stmt`
- [ ] `analyze_stmt`
- [ ] `create_resource_pool_classifier_stmt`
- [ ] `alter_resource_pool_classifier_stmt`
- [ ] `drop_resource_pool_classifier_stmt`
- [ ] `backup_stmt`
- [ ] `restore_stmt`
- [ ] `alter_sequence_stmt`
- [ ] `create_transfer_stmt`
- [ ] `alter_transfer_stmt`
- [ ] `drop_transfer_stmt`
- [ ] `alter_database_stmt`
- [ ] `show_create_table_stmt`
